### PR TITLE
use uuid.Must to ensure UUID generation does not fail

### DIFF
--- a/handler/nats/natspublisher.go
+++ b/handler/nats/natspublisher.go
@@ -127,7 +127,7 @@ func badRequest(logger log.Logger, err error, msg string, writer http.ResponseWr
 
 //connect opens a streaming NATS connection
 func connect(natsUrl, clientId, clusterId string, logger log.Logger) (stan.Conn, CloseConnectionFunc, error) {
-	nc, err := stan.Connect(clusterId, clientId+uuid.NewV4().String(), stan.NatsURL(natsUrl))
+	nc, err := stan.Connect(clusterId, clientId+uuid.Must(uuid.NewV4()).String(), stan.NatsURL(natsUrl))
 	if err != nil {
 		//logger.Error("cannot connect to nats server", zap.Error(err))
 		return nc, nil, err

--- a/handler/nats/nbbtransformer.go
+++ b/handler/nats/nbbtransformer.go
@@ -53,15 +53,15 @@ func NBBTransformMessage(messageContext messageContext, requestContext context.C
 		return nil, errors.New(CharismaIdClaimKey + " claim not found")
 	}
 
-	correlationId := uuid.NewV4()
-	commandId := uuid.NewV4()
+	correlationId := uuid.Must(uuid.NewV4())
+	commandId := uuid.Must(uuid.NewV4())
 	now := time.Now()
 
 	headers := map[string]interface{}{
 		UserIdKey:         userId,
 		CharismaUserIdKey: charismaUserId,
 		CorrelationIdKey:  correlationId,
-		MessageIdKey:      uuid.NewV4(),
+		MessageIdKey:      uuid.Must(uuid.NewV4()),
 		SourceKey:         messageContext.Source,
 		PublishTimeKey:    now,
 	}

--- a/handler/nats/nbbtransformer_test.go
+++ b/handler/nats/nbbtransformer_test.go
@@ -82,8 +82,8 @@ func TestTransformMessage(t *testing.T) {
 func TestBuildResponse(t *testing.T) {
 
 	// Arrange
-	var correlationId = uuid.NewV4()
-	var commandId = uuid.NewV4()
+	var correlationId = uuid.Must(uuid.NewV4())
+	var commandId = uuid.Must(uuid.NewV4())
 
 	var messageContext = messageContext{Headers: map[string]interface{}{
 		CorrelationIdKey: correlationId,

--- a/router/dynamicrouter.go
+++ b/router/dynamicrouter.go
@@ -56,7 +56,7 @@ func AddRoute(router *dynamicRouter) func(path, pathPrefix string, methods []str
 			PathPrefix: pathPrefix,
 			Methods:    methods,
 			handler:    handler,
-			UID:        uuid.NewV4().String(),
+			UID:        uuid.Must(uuid.NewV4()).String(),
 		}
 
 		route.matcher = router.routeMatcher(route)


### PR DESCRIPTION
This pull request standardizes the way UUIDs are generated throughout the codebase by replacing direct calls to `uuid.NewV4()` with `uuid.Must(uuid.NewV4())`. This change ensures that any errors encountered during UUID generation are handled consistently and safely, reducing the risk of unexpected nil values or panics.

UUID generation consistency:

* Replaced all instances of `uuid.NewV4()` with `uuid.Must(uuid.NewV4())` in `handler/nats/natspublisher.go`, `handler/nats/nbbtransformer.go`, `handler/nats/nbbtransformer_test.go`, and `router/dynamicrouter.go` to enforce error checking during UUID creation. [[1]](diffhunk://#diff-8672cbf848a33f1f86de1f323c777425fedfd4c37d036590c7e0ffe6fa7efc22L130-R130) [[2]](diffhunk://#diff-d4fbcc8ad58a0bccb6573debe068591cfe7625ca9a95d55f5641fe72ba035c73L56-R64) [[3]](diffhunk://#diff-154718e9641d636c4b72f6cea0ffba059522d2ec81286e8af660db1ea728853bL85-R86) [[4]](diffhunk://#diff-ed9fb98be98a8ba0e485033e4a476a15b4aa3be666e66bd36219f477151ebd47L59-R59)